### PR TITLE
fix: add urllib to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "merge-descriptors": "^2.0.0",
     "mm": "^4.0.1",
     "sdk-base": "^5.0.0",
+    "urllib": "^4.6.11",
     "utility": "^2.3.0"
   },
   "peerDependencies": {
@@ -69,8 +70,7 @@
     "tsd": "^0.31.2",
     "tshy": "3",
     "tshy-after": "^1.3.1",
-    "typescript": "5",
-    "urllib": "4"
+    "typescript": "5"
   },
   "scripts": {
     "clean": "rimraf dist",

--- a/src/lib/mock_agent.ts
+++ b/src/lib/mock_agent.ts
@@ -2,7 +2,7 @@ import { debuglog } from 'node:util';
 import {
   MockAgent, setGlobalDispatcher, getGlobalDispatcher, Dispatcher,
   HttpClient,
-} from 'egg/urllib';
+} from 'urllib';
 
 const debug = debuglog('@eggjs/mock/lib/mock_agent');
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -85,4 +85,4 @@ export type {
 
 export type {
   MockAgent,
-} from 'egg/urllib';
+} from 'urllib';

--- a/test/fixtures/apps/helloworld/package.json
+++ b/test/fixtures/apps/helloworld/package.json
@@ -3,5 +3,8 @@
   "egg": {
     "typescript": false
   },
-  "type": "module"
+  "type": "module",
+  "devDependencies": {
+    "@eggjs/mock": "6"
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `urllib` package from development to production dependency
	- Added `@eggjs/mock` version 6 to test fixture's development dependencies

- **Import Changes**
	- Modified import source for `MockAgent` and related utilities from `egg/urllib` to `urllib`

These changes appear to be primarily related to package management and import adjustments, with no direct user-facing functionality modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->