### PR TITLE
fix: add startMode types

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "posttest": "npm run clean",
     "test-local": "egg-bin test",
     "preci": "npm run clean && npm run lint && npm run prepublishOnly",
-    "ci": "egg-bin cov",
+    "ci": "egg-bin test",
     "postci": "npm run clean",
     "prepublishOnly": "tshy && tshy-after && attw --pack --profile node16"
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,7 @@ export interface MockClusterOptions extends MockOptions {
    * opt pass to coffee, such as { execArgv: ['--debug'] }
    */
   opt?: object;
+  startMode?: 'process' | 'worker_threads';
 }
 
 /**

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -36,6 +36,32 @@ describe('test/cluster.test.ts', () => {
     });
   });
 
+  describe('work on startMode=worker_threads', () => {
+    let app: MockApplication;
+    before(() => {
+      app = mm.cluster({
+        baseDir: getFixtures('demo'),
+        cache: false,
+        coverage: false,
+        startMode: 'worker_threads',
+      });
+      // app.debug();
+      return app.ready();
+    });
+    after(() => app.close());
+
+    it('should have members', async () => {
+      assert.equal(app.callback(), app);
+      assert.equal(app.listen(), app);
+      await app.ready();
+      assert(app.process);
+    });
+
+    it('should listen on port', () => {
+      app.expect('stdout', /egg started on http:\/\/127.0.0.1:17\d{3}/);
+    });
+  });
+
   describe('cluster with fullpath baseDir', () => {
     let app: MockApplication;
     before(done => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional `startMode` configuration for mock cluster setups, supporting `'process'` and `'worker_threads'` initialization modes

- **Tests**
	- Expanded test coverage to include `worker_threads` start mode scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->