### PR TITLE
fix: remove ContextDelegation

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">= 18.19.0"
   },
   "dependencies": {
-    "@eggjs/core": "^6.2.5",
+    "@eggjs/core": "^6.2.11",
     "@eggjs/supertest": "^8.1.0",
     "@eggjs/utils": "^4.0.3",
     "coffee": "^5.2.1",

--- a/src/app/middleware/cluster_app_mock.ts
+++ b/src/app/middleware/cluster_app_mock.ts
@@ -1,16 +1,17 @@
 import { debuglog } from 'node:util';
-import { ContextDelegation, Next } from '@eggjs/core';
+import { Context, Next } from '@eggjs/core';
 
 const debug = debuglog('@eggjs/mock/app/middleware/cluster_app_mock');
 
 export default () => {
-  return async function clusterAppMock(ctx: ContextDelegation, next: Next) {
+  return async function clusterAppMock(ctx: Context, next: Next) {
     // use originalUrl to make sure other middlewares can't change request url
     if (ctx.originalUrl !== '/__egg_mock_call_function') {
       return next();
     }
-    debug('%s %s, body: %j', ctx.method, ctx.url, ctx.request.body);
-    const { method, property, args, needResult } = ctx.request.body;
+    const body = (ctx.request as any).body;
+    debug('%s %s, body: %j', ctx.method, ctx.url, body);
+    const { method, property, args, needResult } = body;
     if (!method) {
       ctx.status = 422;
       ctx.body = {

--- a/test/fixtures/tegg-app-esm/test/hooks.test.ts
+++ b/test/fixtures/tegg-app-esm/test/hooks.test.ts
@@ -1,14 +1,14 @@
 import assert from 'node:assert';
-import { ContextDelegation } from 'egg';
+import { Context } from 'egg';
 // import { app } from '../../../../src/bootstrap.js';
 import { app } from '../../../../dist/esm/bootstrap.js';
 
 describe('test/hooks.test.ts', () => {
   let beforeCtx;
   let afterCtx;
-  const beforeEachCtxList: Record<string, ContextDelegation> = {};
-  const afterEachCtxList: Record<string, ContextDelegation> = {};
-  const itCtxList: Record<string, ContextDelegation> = {};
+  const beforeEachCtxList: Record<string, Context> = {};
+  const afterEachCtxList: Record<string, Context> = {};
+  const itCtxList: Record<string, Context> = {};
 
   before(async () => {
     beforeCtx = app.currentContext;
@@ -26,41 +26,41 @@ describe('test/hooks.test.ts', () => {
 
   describe('foo', () => {
     beforeEach(() => {
-      beforeEachCtxList.foo = app.currentContext as ContextDelegation;
+      beforeEachCtxList.foo = app.currentContext as Context;
     });
 
     it('should work', () => {
-      itCtxList.foo = app.currentContext as ContextDelegation;
+      itCtxList.foo = app.currentContext as Context;
     });
 
     afterEach(() => {
-      afterEachCtxList.foo = app.currentContext as ContextDelegation;
+      afterEachCtxList.foo = app.currentContext as Context;
     });
   });
 
   describe('bar', () => {
     beforeEach(() => {
-      beforeEachCtxList.bar = app.currentContext as ContextDelegation;
+      beforeEachCtxList.bar = app.currentContext as Context;
     });
 
     it('should work', () => {
-      itCtxList.bar = app.currentContext as ContextDelegation;
+      itCtxList.bar = app.currentContext as Context;
     });
 
     afterEach(() => {
-      afterEachCtxList.bar = app.currentContext as ContextDelegation;
+      afterEachCtxList.bar = app.currentContext as Context;
     });
   });
 
   describe('multi it', () => {
-    const itCtxList: Array<ContextDelegation> = [];
+    const itCtxList: Array<Context> = [];
 
     it('should work 1', () => {
-      itCtxList.push(app.currentContext as ContextDelegation);
+      itCtxList.push(app.currentContext as Context);
     });
 
     it('should work 2', () => {
-      itCtxList.push(app.currentContext as ContextDelegation);
+      itCtxList.push(app.currentContext as Context);
     });
 
     after(() => {

--- a/test/fixtures/tegg-app-esm/test/tegg_context.test.ts
+++ b/test/fixtures/tegg-app-esm/test/tegg_context.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from 'node:assert';
-import { ContextDelegation } from 'egg';
+import { Context } from 'egg';
 // import { app, mm } from '../../../../src/bootstrap.js';
 import { app, mm } from '../../../../dist/commonjs/bootstrap';
 import { LogService } from '../app/modules/foo/LogService';
 
 describe('test/tegg_context.test.ts', () => {
-  let ctx: ContextDelegation;
+  let ctx: Context;
   let logService: LogService;
   before(async () => {
     logService = await app.getEggObject(LogService);

--- a/test/fixtures/tegg-app/test/hooks.test.ts
+++ b/test/fixtures/tegg-app/test/hooks.test.ts
@@ -1,14 +1,14 @@
 import assert from 'node:assert';
-import { ContextDelegation } from 'egg';
+import { Context } from 'egg';
 // import { app } from '../../../../src/bootstrap.js';
 import { app } from '../../../../dist/commonjs/bootstrap';
 
 describe('test/hooks.test.ts', () => {
   let beforeCtx;
   let afterCtx;
-  const beforeEachCtxList: Record<string, ContextDelegation> = {};
-  const afterEachCtxList: Record<string, ContextDelegation> = {};
-  const itCtxList: Record<string, ContextDelegation> = {};
+  const beforeEachCtxList: Record<string, Context> = {};
+  const afterEachCtxList: Record<string, Context> = {};
+  const itCtxList: Record<string, Context> = {};
 
   before(async () => {
     beforeCtx = app.currentContext;
@@ -26,41 +26,41 @@ describe('test/hooks.test.ts', () => {
 
   describe('foo', () => {
     beforeEach(() => {
-      beforeEachCtxList.foo = app.currentContext as ContextDelegation;
+      beforeEachCtxList.foo = app.currentContext as Context;
     });
 
     it('should work', () => {
-      itCtxList.foo = app.currentContext as ContextDelegation;
+      itCtxList.foo = app.currentContext as Context;
     });
 
     afterEach(() => {
-      afterEachCtxList.foo = app.currentContext as ContextDelegation;
+      afterEachCtxList.foo = app.currentContext as Context;
     });
   });
 
   describe('bar', () => {
     beforeEach(() => {
-      beforeEachCtxList.bar = app.currentContext as ContextDelegation;
+      beforeEachCtxList.bar = app.currentContext as Context;
     });
 
     it('should work', () => {
-      itCtxList.bar = app.currentContext as ContextDelegation;
+      itCtxList.bar = app.currentContext as Context;
     });
 
     afterEach(() => {
-      afterEachCtxList.bar = app.currentContext as ContextDelegation;
+      afterEachCtxList.bar = app.currentContext as Context;
     });
   });
 
   describe('multi it', () => {
-    const itCtxList: Array<ContextDelegation> = [];
+    const itCtxList: Array<Context> = [];
 
     it('should work 1', () => {
-      itCtxList.push(app.currentContext as ContextDelegation);
+      itCtxList.push(app.currentContext as Context);
     });
 
     it('should work 2', () => {
-      itCtxList.push(app.currentContext as ContextDelegation);
+      itCtxList.push(app.currentContext as Context);
     });
 
     after(() => {

--- a/test/fixtures/tegg-app/test/tegg_context.test.ts
+++ b/test/fixtures/tegg-app/test/tegg_context.test.ts
@@ -1,11 +1,11 @@
 import { strict as assert } from 'node:assert';
-import { ContextDelegation } from 'egg';
+import { Context } from 'egg';
 // import { app, mm } from '../../../../src/bootstrap.js';
 import { app, mm } from '../../../../dist/commonjs/bootstrap';
 import { LogService } from '../app/modules/foo/LogService';
 
 describe('test/tegg_context.test.ts', () => {
-  let ctx: ContextDelegation;
+  let ctx: Context;
   let logService: LogService;
   before(async () => {
     logService = await app.getEggObject(LogService);

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,12 +1,12 @@
 import { expectType } from 'tsd';
-import { ContextDelegation } from 'egg';
+import { Context } from 'egg';
 import { MockApplication, MockAgent, ResultObject } from '../src/index.js';
 import { getBootstrapApp, mock, mm } from '../src/bootstrap.js';
 
 const app = getBootstrapApp();
 expectType<MockApplication>(app);
-expectType<ContextDelegation | undefined>(app.currentContext as ContextDelegation);
-expectType<ContextDelegation | undefined>(app.ctxStorage.getStore() as ContextDelegation);
+expectType<Context | undefined>(app.currentContext as Context);
+expectType<Context | undefined>(app.ctxStorage.getStore() as Context);
 expectType<MockApplication>(mock.app());
 expectType<MockApplication>(mm.app());
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated `@eggjs/core` dependency from version 6.2.5 to 6.2.11

- **Refactor**
	- Replaced `ContextDelegation` with `Context` across multiple files
	- Updated logging types from `Logger` to `EggLogger`
	- Modified type declarations in test files and application code

- **Tests**
	- Updated type assertions in test files to reflect new context and logging types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->